### PR TITLE
updated user agent string to match a more recent one

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -60,8 +60,8 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20230513.01'
-USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36'
+VERSION = '20230514.01'
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36'
 TRACKER_ID = 'imgur'
 TRACKER_HOST = 'legacy-api.arpa.li'
 MULTI_ITEM_SIZE = 50

--- a/pipeline.py
+++ b/pipeline.py
@@ -61,7 +61,7 @@ if not WGET_AT:
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
 VERSION = '20230514.01'
-USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36'
+USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36'
 TRACKER_ID = 'imgur'
 TRACKER_HOST = 'legacy-api.arpa.li'
 MULTI_ITEM_SIZE = 50


### PR DESCRIPTION
[(Im a noob) But I think it does sense to change the user agent as it makes them think it could be legit traffic by normal users. And avoids the servers to be IP Blocked because they have been identified to belong the same "botnet".](https://element.asra.gr/#/room/!lyMGtUfpDHiyyEDFeP:hackint.org/$k_f8su4RM-bb37OoBOJKX7MFLDWXrFvDkvqQQUTvMJI)

Maybe its a combination: if DatacenterIP+WeirdUserAgent+MuchTraffik > 3       -> Block 

Some tought in irc its the user agents causing the blocking others didnt. One said it would be easier to change IPs then the User Agent. IDK, this change does make sense imho. I didnt tested the codechange.