### PR TITLE
Reduce timeout for 429 errors?

### DIFF
--- a/imgur.lua
+++ b/imgur.lua
@@ -566,7 +566,7 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     io.stdout:write("Server returned bad response. Sleeping.\n")
     io.stdout:flush()
     tries = tries + 1
-    if tries > 8 or status_code == 404 then
+    if tries > 2 or status_code == 404 then
       tries = 0
       abort_item()
       return wget.actions.EXIT


### PR DESCRIPTION
Since imgur apparently returns HTTP error 429 for nearly everyone trying to download MP4s, would it be a good idea to drop the retry count drastically?

Right now almost everyone is wasting time waiting for the 429 to timeout after like 10 attempts, instead of focusing on the JPGs and PNGs that can still be downloaded.